### PR TITLE
#3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Unit tests
+run-name: ${{ github.actor }} is learning Github Actions
+on: #Chooses an event when to run actions
+  pull_request:
+    branches: [main]
+
+jobs: # Jobs consist different of different steps to test/simulate something. If all steps pass, the job is successful.
+  salute: # Job name
+    runs-on: ubuntu-latest # Simulates an environment where the job gets executed. Here we have chosen Linux distribution called Ubuntu
+    steps: # Define steps of the job
+      - name: Show event type # Step name
+        run: echo "Triggered by Event type ${{ github.event_name }}" # Run command runs a bash script/prompt
+      - name: Say hello to person who triggered the actions!
+        run: echo Hello ${{ github.actor }}!
+        
+  frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acces project frontend project files in runner environment
+        uses: actions/checkout@v4
+      - name: Setup node.js environment
+        uses: actions/setup-node@v4
+      - name: Navigate to frontend folder and install node modules
+        run: cd frontend && npm install
+      - name: Run tests 
+        run: cd frontend && npm run test
+
+  # Implement unit tests for backend later

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  env: { browser: true, es2020: true },
+  env: { browser: true, es2020: true, jest:true },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',

--- a/frontend/__tests__/sampleTest.test.ts
+++ b/frontend/__tests__/sampleTest.test.ts
@@ -1,0 +1,3 @@
+test("Sample test 1+1=2", () => {
+    expect(1+1).toBe(2);
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,6 @@
       },
       "devDependencies": {
         "@testing-library/react": "^14.2.2",
-        "@testing-library/react-hooks": "^8.0.1",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -2671,36 +2670,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
-      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
-          "optional": true
-        }
       }
     },
     "node_modules/@types/aria-query": {
@@ -7675,22 +7644,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.2",
-    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",


### PR DESCRIPTION
# Implement workflow for front end unit tests

I had the complete CI/CD workflow ready in another [repository](https://github.com/JerryUusis/gh_actions_practice), but this repository's file structure is different so I will have to edit it to fit this repository.

### Changes

- Implemented a Github action workflow to run unit tests on `frontend` folder each push event to the `main` branch.
- Created `sampleTest` to test that the workflow is running. We can remove this immediately when we have real tests in the `__tests__` folder
- Removed `@testing-library/react-hooks` because it was causing dependency issues when trying to install node modules on `frontend` folder
- Added jest in the env object in `.eslintrc.cjs` to prevent possible whining of ESLint when writing unit tests with Jest