### PR TITLE
#60

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,20 @@
+name: Sonar cloud scan
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Unit tests
-run-name: ${{ github.actor }} is learning Github Actions
+run-name: Unit tests
 on: #Chooses an event when to run actions
   pull_request:
     branches: [main]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=meJubair_SWTP2
+sonar.organization=jubair


### PR DESCRIPTION
# Sonarcloud scan Github Action

Set up the workflow  so it will run Sonarcloud scan on the project with every open pull request on the main branch. There's a possible side-effect that it will run also after a succesful push, but it shouldn't matter.

If everything works as intended, we can set the branch protection rules to have this worklow to be required to be able to merge to the `main` branch.