### PR TITLE
#86

### DIFF
--- a/backend/types/calendarInterface.d.ts
+++ b/backend/types/calendarInterface.d.ts
@@ -1,16 +1,20 @@
-interface Calendar {
+interface CalendarData {
   title: string;
   authorName: string;
   userId: string;
-  calendarDoors: CalendarDoors[];
+  startDate: string;
+  endDate: string;
+  published: boolean;
+  tags: string[];
+  calendarDoors: DoorData[];
 }
 
-interface CalendarDoors {
+interface DoorData {
   doorNumber: number;
   textContent: string;
-  youtubeVideoId?: string;
-  imageFileUrl?: string;
-  videoFileUrl?: string;
+  youtubeVideoId: string;
+  imageFileUrl: string;
+  videFileUrl: string;
 }
 
-export { Calendar, CalendarDoors };
+export { CalendarData, DoorData };

--- a/frontend/src/routes/Calendars.tsx
+++ b/frontend/src/routes/Calendars.tsx
@@ -2,23 +2,44 @@ import { Link } from "react-router-dom";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { CalendarData } from "../../../backend/types/calendarInterface";
 
 const Calendars = () => {
+  const [calendars, setCalendars] = useState<CalendarData[]>([]);
+
+  useEffect(() => {
+    const fetchCalendarData = async () => {
+      const response = await axios.get("http://localhost:3000/calendars");
+      const data = response.data;
+      setCalendars(data);
+    };
+    fetchCalendarData();
+  }, []);
+
   return (
-    <Box>
-      <Box sx={{ height: "calc(100vh - 64px)" }}>
-        <Typography variant="h1" sx={{ textAlign: "center", py: "1rem" }}>
-          My calendars
-        </Typography>
-        <Box
-          sx={{
-            height: "75%",
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
+    <Box sx={{ height: "calc(100vh - 64px)" }}>
+      <Typography variant="h1" sx={{ textAlign: "center", py: "1rem" }}>
+        My calendars
+      </Typography>
+      <Box
+        sx={{
+          height: "75%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        {calendars.length === 0 ? (
           <Box
             sx={{
               display: "flex",
@@ -37,7 +58,48 @@ const Calendars = () => {
               </Button>
             </Link>
           </Box>
-        </Box>
+        ) : (
+          <TableContainer
+            component={Paper}
+            sx={{ width: "70%", maxWidth: "1000px" }}
+          >
+            <Table>
+              <TableHead
+                sx={{
+                  position: "sticky",
+                  top: 0,
+                  zIndex: 2,
+                  backgroundColor: "secondary.main",
+                }}
+              >
+                <TableRow sx={{ color: "red" }}>
+                  <TableCell sx={{ fontWeight: "bold" }}>Name</TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Date Range</TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Doors</TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Tags</TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>
+                    Publish status
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {calendars.map((calendar) => (
+                  <TableRow key={calendar.title}>
+                    <TableCell>{calendar.title}</TableCell>
+                    <TableCell>
+                      {calendar.startDate} - {calendar.endDate}
+                    </TableCell>
+                    <TableCell>{calendar.calendarDoors.length}</TableCell>
+                    <TableCell>{calendar.tags.join(", ")}</TableCell>
+                    <TableCell>
+                      {calendar.published ? "Published" : "Unpublished"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
       </Box>
     </Box>
   );

--- a/frontend/src/services/db.json
+++ b/frontend/src/services/db.json
@@ -1,0 +1,224 @@
+{
+  "calendars": [
+    {
+      "title": "Family summer",
+      "authorName": "Barney Boddingtion",
+      "userId": "",
+      "startDate": "1.6.2025",
+      "endDate": "4.6.2025",
+      "published": true,
+      "tags": ["Summer", "Vacation"],
+      "backgroundUrl": "",
+      "calendarDoors": [
+        {
+          "doorNumber": "1",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "2",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "3",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "4",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        }
+      ]
+    },
+    {
+      "title": "Christmas 2025",
+      "authorName": "Barney Boddingtion",
+      "userId": "",
+      "startDate": "1.12.2025",
+      "endDate": "24.12.2025",
+      "published": false,
+      "tags": ["Christmas"],
+      "backgroundUrl": "",
+      "calendarDoors": [
+        {
+          "doorNumber": "1",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "2",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "3",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "4",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "5",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "6",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "7",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "8",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "9",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "10",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "11",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "12",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "13",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "14",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "15",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "16",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "17",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "18",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "19",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "20",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "21",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "22",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "23",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        },
+        {
+          "doorNumber": "24",
+          "textContent": "",
+          "youtubeVideoId": "",
+          "imageFileUrl": "",
+          "videoFileUrl": ""
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# #86: My Calendars: Add Table to visualize calendars

Updated `Calendars.tsx` now to display a table of user's maps (with mock data). 

### `calendarInterface.d.ts`
- Update the interfaces `CalendarData` and `DoorData` to better represent the data structure of Calendar objects (for now)

### `Calendar.tsx`

- Add useEffect to fetch mock data with json-server (should be refactored once database's data structure is formed better)
- Import `Table` and it's related subcomponents
- Conditionally render `Table` if user has any Calendar data on their account
- If user has no calendar data, render "No calendars found" 

### `db.json`

- Used for simulating database with two different instances of calendars

