### PR TITLE
#89

### DIFF
--- a/backend/controllers/calendar.ts
+++ b/backend/controllers/calendar.ts
@@ -5,6 +5,7 @@ import {
   loginWithEmailAndPassword,
   getLoggedUserName,
   logout,
+  addCalendarToFirebase,
 } from "../services/firebaseService";
 
 const calendarRouter = express.Router();
@@ -62,6 +63,18 @@ calendarRouter.post("/login", async (request: Request, response: Response) => {
     const { email, password } = request.body;
     await loginWithEmailAndPassword(email, password);
     response.status(200).end("Login succesful");
+  } catch (error) {
+    console.log(error);
+    response.status(500).json({ error: error });
+  }
+});
+
+// Create new calendar instance
+calendarRouter.post("/new", async (request: Request, response: Response) => {
+  try {
+    const body = request.body;
+    await addCalendarToFirebase(body.id, body);
+    response.json(body);
   } catch (error) {
     console.log(error);
     response.status(500).json({ error: error });

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -13,6 +13,7 @@ import {
   where,
 } from "firebase/firestore";
 import { FIREBASE_API_KEY } from "../utils/config";
+import { CalendarData } from "../types/calendarInterface";
 
 const firebaseConfig = {
   apiKey: FIREBASE_API_KEY,
@@ -113,13 +114,22 @@ const getLoggedUserName = async () => {
 // Log current user out
 const logout = async () => {
   try {
-    await auth.signOut()
+    await auth.signOut();
     console.log("User successfully logged out");
-  }
-  catch(error) {
+  } catch (error) {
     console.error("Error signing out:", error);
   }
-}
+};
+
+// Create a new calendar document in calendars/uid/calendars
+const addCalendarToFirebase = async (uid: string, calendar: CalendarData) => {
+  try {
+    const calendarRef = collection(db, `calendars/${uid}/calendars`);
+    await addDoc(calendarRef, calendar);
+  } catch (error) {
+    console.error("Error creating new calendar:", error);
+  }
+};
 
 export {
   auth,
@@ -128,5 +138,6 @@ export {
   registerWithEmailAndPassword,
   loginWithEmailAndPassword,
   getLoggedUserName,
-  logout
+  logout,
+  addCalendarToFirebase,
 };


### PR DESCRIPTION
# #89: Create a new calendar instance in the database

REST server is now adding instances of calendar in to the database in calendars/uid/calendars

## `calendar.ts`

- Server is now handling POST requests on /api/calendars to create new instances of calendars in the database

## `firebaseService`

- Added `addCalendarToFirebase()` function to handle creating new docs in the database