### PR TITLE
#93

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -145,7 +145,7 @@ function Header() {
           <Box sx={{ display: { xs: "none", sm: "block" } }}>
             {isLoggedIn ? (
               <>
-                <Link to={""}>
+                <Link to={"/calendars"}>
                   <Button sx={{ color: "#0b2027" }}>My Calendars</Button>
                 </Link>
                 <Button sx={{ color: "#0b2027" }} onClick={logUserOut}>

--- a/frontend/src/routes/Calendars.tsx
+++ b/frontend/src/routes/Calendars.tsx
@@ -9,21 +9,27 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import axios from "axios";
-import { CalendarData } from "../../../backend/types/calendarInterface";
+import { useDispatch, useSelector } from "react-redux";
+import { setCalendars } from "../store/calendarSlice";
+import { ReduxCalendarState } from "../store/stateTypes";
 
 const Calendars = () => {
-  const [calendars, setCalendars] = useState<CalendarData[]>([]);
+  const dispatch = useDispatch();
+  const calendars = useSelector(
+    (state: ReduxCalendarState) => state.calendar.calendars
+  );
 
   useEffect(() => {
     const fetchCalendarData = async () => {
+      // Change this to fetch data from the REST server once we have initiated the endpoint to fetch editor user's calendars
       const response = await axios.get("http://localhost:3000/calendars");
       const data = response.data;
-      setCalendars(data);
+      dispatch(setCalendars(data));
     };
     fetchCalendarData();
-  }, []);
+  }, [dispatch]);
 
   return (
     <Box sx={{ height: "calc(100vh - 64px)" }}>

--- a/frontend/src/store/calendarSlice.ts
+++ b/frontend/src/store/calendarSlice.ts
@@ -1,11 +1,16 @@
-import {createSlice} from '@reduxjs/toolkit';
+import { createSlice } from "@reduxjs/toolkit";
 
 export const calendarSlice = createSlice({
-    name: 'calendar',
-    initialState: {
-        calendars: [],
+  name: "calendar",
+  initialState: {
+    calendars: [],
+  },
+  reducers: {
+    setCalendars: (state, action) => {
+      state.calendars = action.payload;
     },
-    reducers: {}
-})
+  },
+});
 
+export const { setCalendars } = calendarSlice.actions;
 export default calendarSlice.reducer;

--- a/frontend/src/store/stateTypes.d.ts
+++ b/frontend/src/store/stateTypes.d.ts
@@ -1,3 +1,5 @@
+import CalendarData from "../../../backend/types/calendarInterface"
+
 interface ReduxUserState {
   user: {
     userLoggedIn: boolean;
@@ -6,4 +8,10 @@ interface ReduxUserState {
   };
 }
 
-export { ReduxUserState }
+interface ReduxCalendarState {
+  calendar: {
+    calendars: CalendarData[]
+  }
+}
+
+export { ReduxUserState, ReduxCalendarState }


### PR DESCRIPTION
# #93: Save Calendar data in Redux state

Calendars array in `calendarSlice.ts` now gets populated with the useEffect in `Calendars.tsx`. Now we can access mock data from the Redux store using `useSelector()` and bringing the state where it is needed.

### `Header.tsx`
- Add missing route to /calendars

## `Calendars.tsx`
- Save the mock data in the state of calendars array `calendarSlice.ts` 
- Map the data from the state of calendars array in Redux store
- Import `ReduxcalanedarState` to be used with `calendars` state

## `calendarSlice.ts`
- Add `setCalendars` reducer and lint code
- Update imports

## `stateTypes.d.ts`
- Add `ReduxCalendarState` interface to be used when using `useSelector` to access the `calendarSlice` states
- Update exports

