### PR TITLE
#99

### DIFF
--- a/backend/controllers/calendar.ts
+++ b/backend/controllers/calendar.ts
@@ -79,9 +79,8 @@ calendarRouter.post("/login", async (request: Request, response: Response) => {
 // Create new calendar instance
 calendarRouter.post("/new", async (request: Request, response: Response) => {
   try {
-    const body = request.body;
-    await addCalendarToFirebase(body.id, body);
-    response.json(body);
+    await addCalendarToFirebase(request.body.uid);
+    response.status(201).end("New calendar created");
   } catch (error) {
     console.log(error);
     response.status(500).json({ error: error });

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -131,19 +131,19 @@ const logout = async () => {
 
 // Create a new calendar document in calendars/uid/calendars
 const addCalendarToFirebase = async (uid: string) => {
-  // Create a new blank calendar object in the 
-  const calendar : CalendarData = {
-      calendarId: "",
-      title: "",
-      authorName: "",
-      startDate: "",
-      endDate: "",
-      published: false,
-      tags: [],
-      backgroundUrl: "",
-      backgroundColour: "",
-      calendarDoors: []
-  }
+  // Create a new blank calendar object in the
+  const calendar: CalendarData = {
+    calendarId: "",
+    title: "",
+    authorName: "",
+    startDate: "",
+    endDate: "",
+    published: false,
+    tags: [],
+    backgroundUrl: "",
+    backgroundColour: "",
+    calendarDoors: [],
+  };
   try {
     // Reference the calendars collection
     const calendarRef = collection(db, `calendars/${uid}/calendars`);
@@ -153,10 +153,9 @@ const addCalendarToFirebase = async (uid: string) => {
     // Set the newly created document's id to calendarId property
     const calendarId = docRef.id;
     calendar.calendarId = calendarId;
-    
-    // Update the document's calendarId in the document
-    await updateDoc(docRef, {calendarId})
 
+    // Update the document's calendarId in the document
+    await updateDoc(docRef, { calendarId });
   } catch (error) {
     console.error("Error creating new calendar:", error);
   }

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -12,6 +12,7 @@ import {
   getFirestore,
   query,
   where,
+  updateDoc,
 } from "firebase/firestore";
 import { FIREBASE_API_KEY } from "../utils/config";
 import { CalendarData } from "../types/calendarInterface";
@@ -129,10 +130,33 @@ const logout = async () => {
 };
 
 // Create a new calendar document in calendars/uid/calendars
-const addCalendarToFirebase = async (uid: string, calendar: CalendarData) => {
+const addCalendarToFirebase = async (uid: string) => {
+  // Create a new blank calendar object in the 
+  const calendar : CalendarData = {
+      calendarId: "",
+      title: "",
+      authorName: "",
+      startDate: "",
+      endDate: "",
+      published: false,
+      tags: [],
+      backgroundUrl: "",
+      backgroundColour: "",
+      calendarDoors: []
+  }
   try {
+    // Reference the calendars collection
     const calendarRef = collection(db, `calendars/${uid}/calendars`);
-    await addDoc(calendarRef, calendar);
+    // Add a new calendar document to the collection
+    const docRef = await addDoc(calendarRef, calendar);
+
+    // Set the newly created document's id to calendarId property
+    const calendarId = docRef.id;
+    calendar.calendarId = calendarId;
+    
+    // Update the document's calendarId in the document
+    await updateDoc(docRef, {calendarId})
+
   } catch (error) {
     console.error("Error creating new calendar:", error);
   }

--- a/backend/types/calendarInterface.d.ts
+++ b/backend/types/calendarInterface.d.ts
@@ -1,11 +1,13 @@
 interface CalendarData {
+  calendarId: string;
   title: string;
   authorName: string;
-  userId: string;
   startDate: string;
   endDate: string;
   published: boolean;
   tags: string[];
+  backgroundUrl: string;
+  backgroundColour: string;
   calendarDoors: DoorData[];
 }
 


### PR DESCRIPTION
# #99: Refactor POST functionality for creating new calendar objects

Refactored the endpoint /new to create a new calendar instance in the database with an identifier. 

### `calendar.ts`
- Refactor the post to user's `uid` during POST

### `firebaseService.ts`
- import updateDoc
- Refactor `addCalendarToFirebase()`
  - Creates now a new "blank" instance in the database in "calendars/`uid`/calendars"
  - Immediately update the `calendarId` to match the document id to give the instance a stable identifier
  
### `calendarInterface.d.ts`
- Update the format to reflect the current ideas about how the data should look like

