### PR TITLE
#100

### DIFF
--- a/backend/controllers/calendar.ts
+++ b/backend/controllers/calendar.ts
@@ -16,18 +16,6 @@ const upload = multer({
   limits: { fileSize: 1024 * 1024 * 5 }, // max file size 1024 bytes * 1024 bytes = 5 megabytes
 });
 
-// Get user calendars from database
-calendarRouter.get("/:uid", async (request: Request, response: Response) => {
-  try {
-    const uid = request.params.uid;
-    const calendarData = await getUserCalendarDataFromFirebase(uid);
-    response.json(calendarData);
-  } catch (error) {
-    console.error("Error when fetching calendar data:", error);
-    response.status(500).json({ error: "Internal server error" });
-  }
-});
-
 // Return user auth data, username and a boolean for updating login state on front end
 calendarRouter.get("/auth", async (request: Request, response: Response) => {
   try {
@@ -75,6 +63,18 @@ calendarRouter.post("/login", async (request: Request, response: Response) => {
   } catch (error) {
     console.log(error);
     response.status(500).json({ error: error });
+  }
+});
+
+// Get user calendars from database
+calendarRouter.get("/:uid", async (request: Request, response: Response) => {
+  try {
+    const uid = request.params.uid;
+    const calendarData = await getUserCalendarDataFromFirebase(uid);
+    response.json(calendarData);
+  } catch (error) {
+    console.error("Error when fetching calendar data:", error);
+    response.status(500).json({ error: "Internal server error" });
   }
 });
 

--- a/backend/controllers/calendar.ts
+++ b/backend/controllers/calendar.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from "express";
 import multer from "multer";
 import {
-  getCalendarDataFromFirebase,
+  getUserCalendarDataFromFirebase,
   registerWithEmailAndPassword,
   loginWithEmailAndPassword,
   getAuthData,
@@ -16,9 +16,11 @@ const upload = multer({
   limits: { fileSize: 1024 * 1024 * 5 }, // max file size 1024 bytes * 1024 bytes = 5 megabytes
 });
 
-calendarRouter.get("/", async (request: Request, response: Response) => {
+// Get user calendars from database
+calendarRouter.get("/:uid", async (request: Request, response: Response) => {
   try {
-    const calendarData = await getCalendarDataFromFirebase();
+    const uid = request.params.uid;
+    const calendarData = await getUserCalendarDataFromFirebase(uid);
     response.json(calendarData);
   } catch (error) {
     console.error("Error when fetching calendar data:", error);

--- a/backend/controllers/calendar.ts
+++ b/backend/controllers/calendar.ts
@@ -81,8 +81,8 @@ calendarRouter.get("/:uid", async (request: Request, response: Response) => {
 // Create new calendar instance
 calendarRouter.post("/new", async (request: Request, response: Response) => {
   try {
-    await addCalendarToFirebase(request.body.uid);
-    response.status(201).end("New calendar created");
+    const dbResponse = await addCalendarToFirebase(request.body.uid);
+    response.json(dbResponse);
   } catch (error) {
     console.log(error);
     response.status(500).json({ error: error });

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -42,7 +42,9 @@ const db = getFirestore(app);
 // Get all from "calendars"
 const getUserCalendarDataFromFirebase = async (uid: string) => {
   try {
-    const querySnapshot = await getDocs(collection(db, `calendars/${uid}/calendars`));
+    const querySnapshot = await getDocs(
+      collection(db, `calendars/${uid}/calendars`)
+    );
     const calendars = querySnapshot.docs.map((doc) => doc.data());
     return calendars;
   } catch (error) {
@@ -156,6 +158,8 @@ const addCalendarToFirebase = async (uid: string) => {
 
     // Update the document's calendarId in the document
     await updateDoc(docRef, { calendarId });
+    // Return the new calendar's calendarId
+    return { calendarId: calendarId };
   } catch (error) {
     console.error("Error creating new calendar:", error);
   }

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -40,9 +40,9 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 
 // Get all from "calendars"
-const getCalendarDataFromFirebase = async () => {
+const getUserCalendarDataFromFirebase = async (uid: string) => {
   try {
-    const querySnapshot = await getDocs(collection(db, "calendars"));
+    const querySnapshot = await getDocs(collection(db, `calendars/${uid}/calendars`));
     const calendars = querySnapshot.docs.map((doc) => doc.data());
     return calendars;
   } catch (error) {
@@ -194,7 +194,7 @@ const getFileDownloadUrl = async (uid: string, fileName: string) => {
 export {
   auth,
   db,
-  getCalendarDataFromFirebase,
+  getUserCalendarDataFromFirebase,
   registerWithEmailAndPassword,
   loginWithEmailAndPassword,
   getAuthData,

--- a/frontend/src/routes/Calendars.tsx
+++ b/frontend/src/routes/Calendars.tsx
@@ -10,26 +10,28 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import { useEffect } from "react";
-import axios from "axios";
 import { useDispatch, useSelector } from "react-redux";
 import { setCalendars } from "../store/calendarSlice";
-import { ReduxCalendarState } from "../store/stateTypes";
+import { ReduxCalendarState, ReduxUserState } from "../store/stateTypes";
+import { getUserCalendarData } from "../services/calendarService";
 
 const Calendars = () => {
   const dispatch = useDispatch();
   const calendars = useSelector(
     (state: ReduxCalendarState) => state.calendar.calendars
   );
+  const uid = useSelector((state: ReduxUserState) => state.user.uid);
 
   useEffect(() => {
     const fetchCalendarData = async () => {
-      // Change this to fetch data from the REST server once we have initiated the endpoint to fetch editor user's calendars
-      const response = await axios.get("http://localhost:3000/calendars");
-      const data = response.data;
-      dispatch(setCalendars(data));
+      const response = await getUserCalendarData(uid);
+      if (response && response.status === 200) {
+        const data = response.data;
+        dispatch(setCalendars(data));
+      }
     };
     fetchCalendarData();
-  }, [dispatch]);
+  }, [dispatch, uid]);
 
   return (
     <Box sx={{ height: "calc(100vh - 64px)" }}>
@@ -85,13 +87,13 @@ const Calendars = () => {
               </TableHead>
               <TableBody>
                 {calendars.map((calendar, i) => (
-                  <TableRow key={calendar.title}>
+                  <TableRow key={calendar.calendarId}>
                     <TableCell>
                       <Link
-                        to={`/calendars/${calendar.title}`}
+                        to={`/calendars/${calendar.calendarId}`}
                         state={{ calendar: calendar, index: i }}
                       >
-                        {calendar.title}
+                        {calendar.title ? calendar.title : "Untitled calendar"}
                       </Link>
                     </TableCell>
 

--- a/frontend/src/routes/Calendars.tsx
+++ b/frontend/src/routes/Calendars.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
@@ -13,15 +13,20 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setCalendars } from "../store/calendarSlice";
 import { ReduxCalendarState, ReduxUserState } from "../store/stateTypes";
-import { getUserCalendarData } from "../services/calendarService";
+import {
+  getUserCalendarData,
+  createNewCalendar,
+} from "../services/calendarService";
 
 const Calendars = () => {
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const calendars = useSelector(
     (state: ReduxCalendarState) => state.calendar.calendars
   );
   const uid = useSelector((state: ReduxUserState) => state.user.uid);
 
+  // Fetch user calendars and update the data in the Redux store
   useEffect(() => {
     const fetchCalendarData = async () => {
       const response = await getUserCalendarData(uid);
@@ -31,7 +36,19 @@ const Calendars = () => {
       }
     };
     fetchCalendarData();
-  }, [dispatch, uid]);
+  }, []);
+
+  // Create a new calendar instance in the database and redirect the user into calendars/calendarId
+  const handleCreateCalendar = async (uid: string) => {
+    try {
+      const response = await createNewCalendar(uid);
+      if (response && response.status === 200) {
+        navigate(`${response.data.calendarId}`);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
 
   return (
     <Box sx={{ height: "calc(100vh - 64px)" }}>
@@ -111,11 +128,14 @@ const Calendars = () => {
             </Table>
           </TableContainer>
         )}
-        <Link to="/calendars/newcalendar" style={{ margin: "20px 0" }}>
-          <Button color="secondary" variant="contained">
-            create calendar
-          </Button>
-        </Link>
+        <Button
+          sx={{ margin: "20px 0" }}
+          color="secondary"
+          variant="contained"
+          onClick={() => handleCreateCalendar(uid)}
+        >
+          create calendar
+        </Button>
       </Box>
     </Box>
   );

--- a/frontend/src/services/calendarService.ts
+++ b/frontend/src/services/calendarService.ts
@@ -11,6 +11,16 @@ const getUserCalendarData = async (uid: string) => {
   }
 };
 
+// Create a new calendar instance in the database in calendars/uid/calendars collection
+const createNewCalendar = async (uid: string) => {
+  try {
+    const response = await axios.post(`${baseUrl}/new`, { uid: uid });
+    return response;
+  } catch (error) {
+    console.error("Error when creating a new calendar:", error);
+  }
+};
+
 const registerUser = async (userObject: {
   username: string;
   email: string;
@@ -56,4 +66,11 @@ const signOut = async () => {
   }
 };
 
-export { registerUser, loginUser, getAuth, signOut, getUserCalendarData };
+export {
+  registerUser,
+  loginUser,
+  getAuth,
+  signOut,
+  getUserCalendarData,
+  createNewCalendar,
+};

--- a/frontend/src/services/calendarService.ts
+++ b/frontend/src/services/calendarService.ts
@@ -1,6 +1,16 @@
 import axios from "axios";
 const baseUrl: string = "http://localhost:3001/api/calendars";
 
+// Get user's calendar data from the database from calendars/uid/calendars collection
+const getUserCalendarData = async (uid: string) => {
+  try {
+    const response = await axios.get(`${baseUrl}/${uid}`);
+    return response;
+  } catch (error) {
+    console.error("Error when fetching user calendar data:", error);
+  }
+};
+
 const registerUser = async (userObject: {
   username: string;
   email: string;
@@ -23,29 +33,27 @@ const loginUser = async (userObject: { email: string; password: string }) => {
   }
 };
 
-const getAuth = async() => {
+const getAuth = async () => {
   try {
-    const response = await axios.get(`${baseUrl}/auth`)
-    return response
+    const response = await axios.get(`${baseUrl}/auth`);
+    return response;
+  } catch (error) {
+    console.error(error);
   }
-  catch (error) {
-    console.error(error)
-  }
-}
-  
-// Return true if request to /logout was succesful
-const signOut = async() => {
-  try {
-    const response = await axios.get(`${baseUrl}/logout`)
-    if (response.status === 200) {
-      return (true)
-    } else {
-      return false
-    }
-  }
-  catch(error) {
-    console.error(error)
-  }
-}
+};
 
-export { registerUser, loginUser, getAuth, signOut };
+// Return true if request to /logout was succesful
+const signOut = async () => {
+  try {
+    const response = await axios.get(`${baseUrl}/logout`);
+    if (response.status === 200) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export { registerUser, loginUser, getAuth, signOut, getUserCalendarData };


### PR DESCRIPTION
# #100: Implement functionality to create a new calendar instance in the front end

New calendar instances can now be created for the user from the front from "create calendar" button. It will get stored to the database and Redux state. `Calendars.tsx` will now fetch user's calendardata from the database. Routes/paths for calendars in the table have now also been updated into following format:  calendars/`calendarId`.

## Backend

### `calendar.ts`
- Created GET endpoint at `/:uid` to get user's calendardata from calendars collection
- Refactored POST endpoint at `/new` to respond with the newly created calendar's `calendarId` value

### `firebaseService.ts`

- Refactor `getUserCalendarDataFromFirebase(uid)` to return user's calendardata from the database from users/`uid`/calendars 
- Refactor `addCalendarToFirebase()` to return now the newly created `calendarId` value to the REST server


## Frontend 

### `Calendars.tsx`
- Import `useNavigate()` hook
- Import `createNewCalendar()`
- Refactor `useEffect` hook to get data from the database and update it to the Redux state
- Add `handleCreateCalendar()` function to create a new calendar and redirect the user to the newly created calendar's `calendarId`
- Updated the mapping parameters 
  - `key` to `calendarId` 
  - `Link` element's `to` property calendars/`calendarId`
  - Conditional rendering if calendar title is empty string

### `calendarService.ts`
- Add `getUserCalendarData()` function
- Add  `createNewCalendar()` function
- Lint the code

