### PR TITLE
#109

### DIFF
--- a/backend/controllers/calendar.ts
+++ b/backend/controllers/calendar.ts
@@ -3,8 +3,8 @@ import multer from "multer";
 import {
   getUserCalendarDataFromFirebase,
   addCalendarToFirebase,
-  uploadToFirebaseStorage,
-  getFileDownloadUrl,
+  uploadCalendarBackroundImageToStorage,
+  getCalendarBackgroundDownloadUrl,
   removeCalendarFromFirebase,
   updateCalendarField,
   updateCalendarObjectInFirebase,
@@ -94,19 +94,20 @@ calendarRouter.delete(
   }
 );
 
-// Handle file upload using Multer (upload.single("file"))
+// Handle calendar background image upload using Multer (upload.single("file"))
+// Make sure that the file is under a key of "file"
 calendarRouter.post(
-  "/upload",
+  "/:uid/:calendarId/upload/calendar_background",
   upload.single("file"),
   async (request: Request, response: Response) => {
     try {
       const file = request.file;
-      const { uid } = request.body;
+      const { uid, calendarId } = request.params;
       if (!file || !uid) {
         response.json(400).json({ error: "File or UID not provided" });
         return;
       }
-      await uploadToFirebaseStorage(file, uid); // Upload the file in to Firebase Storage
+      await uploadCalendarBackroundImageToStorage(file, uid, calendarId); // Upload the file in to Firebase Storage
       response.status(200).end("File succesfully uploaded");
     } catch (error) {
       response.status(500).json({ error: error });
@@ -114,13 +115,13 @@ calendarRouter.post(
   }
 );
 
-// Endpoint for getting file download URL from the storage
+// Endpoint for getting background image file download URL from the storage
 calendarRouter.get(
-  "/getfileurl",
+  "/:uid/:calendarId/calendar_background",
   async (request: Request, response: Response) => {
     try {
-      const { uid, fileName } = request.body;
-      const fileUrl = await getFileDownloadUrl(uid, fileName);
+      const { uid, calendarId } = request.params;
+      const fileUrl = await getCalendarBackgroundDownloadUrl(uid, calendarId);
       response.json(fileUrl);
     } catch (error) {
       console.log(error);

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -186,19 +186,21 @@ const removeCalendarFromFirebase = async (calendarId: string, uid: string) => {
   }
 };
 
-// Upload user's files to FirebaseStorage in users/<uid>/<filename>
-const uploadToFirebaseStorage = async (
+// Upload user's files to Firebase Storage in users/<uid>/<filename>
+const uploadCalendarBackroundImageToStorage = async (
   file: Express.Multer.File,
-  uid: string
+  uid: string,
+  calendarId: string
 ) => {
   try {
     // Create a reference to user's storage location/path
-    const userStorageRef = ref(storage, `users/${uid}/${file.originalname}`);
+    const userStorageRef = ref(storage, `users/${uid}/${calendarId}/calendarBackground/backgroundImage`);
 
     // Determine the correct MIME type or use "default"
     const mimeType = file.mimetype || "application/octet-stream";
 
     await uploadBytes(userStorageRef, file.buffer, { contentType: mimeType }); // Upload the file in to the storage
+    return userStorageRef
   } catch (error) {
     console.error("Error uploading file:", error);
     throw error;
@@ -261,9 +263,9 @@ const updateCalendarObjectInFirebase = async (
   }
 };
 
-const getFileDownloadUrl = async (uid: string, fileName: string) => {
+const getCalendarBackgroundDownloadUrl = async (uid: string, calendarId: string) => {
   try {
-    const fileRef = ref(storage, `users/${uid}/${fileName}`);
+    const fileRef = ref(storage, `users/${uid}/${calendarId}/calendarBackground/backgroundImage`);
     const fileUrl = await getDownloadURL(fileRef);
     return fileUrl;
   } catch (error) {
@@ -281,8 +283,8 @@ export {
   getAuthData,
   logout,
   addCalendarToFirebase,
-  uploadToFirebaseStorage,
-  getFileDownloadUrl,
+  uploadCalendarBackroundImageToStorage,
+  getCalendarBackgroundDownloadUrl,
   removeCalendarFromFirebase,
   updateCalendarField,
   updateCalendarObjectInFirebase,

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -23,7 +23,11 @@ import {
 import CalendarTags from "../components/CalendarTags";
 import { setIsTyping, setSaved } from "../store/syncSlice";
 import AutoSave from "../components/AutoSave";
-import { updateCalendarObject } from "../services/calendarService";
+import {
+  updateCalendarObject,
+  uploadCalendarBackroundImage,
+  getBackgroundImage,
+} from "../services/calendarService";
 import { CalendarData } from "../../../backend/types/calendarInterface";
 
 const EditorViewMain: React.FC = () => {
@@ -218,13 +222,17 @@ const EditorViewMain: React.FC = () => {
   };
 
   // Handle image upload from device or URL
-  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files?.[0];
     const imageUrl = e.target.value;
+    dispatch(setIsTyping(true));
+    typingResetTimer(timerRef);
 
     if (files) {
-      const imageUrl = URL.createObjectURL(files);
-      setUploadedImageUrl(imageUrl);
+      // const imageUrl = URL.createObjectURL(files);
+      await uploadCalendarBackroundImage(uid, calendarId, files);
+      // Get background image download link from storage
+      const imageUrl = await getBackgroundImage(uid, calendarId);
       dispatch(
         setCalendarBackgroundUrl({ calendarIndex, newBackgroundUrl: imageUrl })
       );
@@ -241,6 +249,8 @@ const EditorViewMain: React.FC = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
+    dispatch(setIsTyping(true));
+    typingResetTimer(timerRef);
     setUploadedImageUrl(null);
     dispatch(setCalendarBackgroundUrl({ calendarIndex, newBackgroundUrl: "" }));
   };
@@ -389,8 +399,8 @@ const EditorViewMain: React.FC = () => {
             height: "800px",
             border: "1px solid black",
             borderRadius: "5px",
-            backgroundImage: uploadedImageUrl
-              ? `url(${uploadedImageUrl})`
+            backgroundImage: calendar.backgroundUrl
+              ? `url(${calendar.backgroundUrl})`
               : "none",
             backgroundSize: "cover",
             backgroundPosition: "center",

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -226,7 +226,6 @@ const EditorViewMain: React.FC = () => {
     const files = e.target.files?.[0];
     const imageUrl = e.target.value;
     dispatch(setIsTyping(true));
-    typingResetTimer(timerRef);
 
     if (files) {
       await uploadCalendarBackroundImage(uid, calendarId, files);
@@ -241,6 +240,7 @@ const EditorViewMain: React.FC = () => {
         setCalendarBackgroundUrl({ calendarIndex, newBackgroundUrl: imageUrl })
       );
     }
+    typingResetTimer(timerRef);
   };
 
   // Reset the uploaded image

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -229,7 +229,6 @@ const EditorViewMain: React.FC = () => {
     typingResetTimer(timerRef);
 
     if (files) {
-      // const imageUrl = URL.createObjectURL(files);
       await uploadCalendarBackroundImage(uid, calendarId, files);
       // Get background image download link from storage
       const imageUrl = await getBackgroundImage(uid, calendarId);

--- a/frontend/src/services/calendarService.ts
+++ b/frontend/src/services/calendarService.ts
@@ -65,10 +65,38 @@ const updateCalendarObject = async (
   }
 };
 
+// Upload calendarBackroundImage to the storage
+const uploadCalendarBackroundImage = async (
+  uid: string,
+  calendarId: string,
+  file: File
+) => {
+  try {
+    // Create a new FormData object to handle the file with Multer
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const response = await axios.post(
+      `${baseUrl}/${uid}/${calendarId}/upload/calendar_background`,
+      formData,
+      {
+        // Set content type for file upload to work with Multer
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+    return response;
+  } catch (error) {
+    console.error("Error when uploading backround image:", error);
+  }
+};
+
 export {
   getUserCalendarData,
   createNewCalendar,
   removeCalendar,
   updateSingleValue,
-  updateCalendarObject
+  updateCalendarObject,
+  uploadCalendarBackroundImage,
 };

--- a/frontend/src/services/calendarService.ts
+++ b/frontend/src/services/calendarService.ts
@@ -92,6 +92,18 @@ const uploadCalendarBackroundImage = async (
   }
 };
 
+// Get backround image download URL from storage
+const getBackgroundImage = async (uid: string, calendarId: string) => {
+  try {
+    const response = await axios.get(
+      `${baseUrl}/${uid}/${calendarId}/calendar_background`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error getting background image url:", error);
+  }
+};
+
 export {
   getUserCalendarData,
   createNewCalendar,
@@ -99,4 +111,5 @@ export {
   updateSingleValue,
   updateCalendarObject,
   uploadCalendarBackroundImage,
+  getBackgroundImage,
 };


### PR DESCRIPTION
# #109: Store user's background image in the storage

User's uploaded images now get stored to to the storage in path: "users/`uid`/`calendarId`/calendarBackround/". If user uploads an image there it will be called `backroundImage`. If user decides to upload another image, then the original `backgroundImage` will get replaced but the name will still be `backgroundImage`.

Changes done in the front end for setting background image from a file or a URL will now get stored in the database and Redux store.

## Backend

### `calendar.ts`
- Refactor the file upload functions to be fitting for uploading and getting calendar background image from the storage
- Images can be uploaded now on the server with POST at localhost:3001/api/calendar/`:uid`/`:calendarId`/upload/calendar_background
- Background image download link can be accessed with GET at localhost:3001/api/calendar/`:uid`/`:calendarId`/calendar_background

### `firebaseService.ts`
- Add `uploadCalendarBackroundImageToStorage()` to to upload images in the storage
- Add `getCalendarBackgroundDownloadUrl()` to get download link for calendar's background image (it's coming from the storage)

## Frontend
### `EditorViewMain.tsx`
- Refactor `handleImageUpload()` function 
- Import `uploadCalendarBackroundImage()` and `getBackgroundImage()` functions to handle requests to the backend
- Implement "autosave" feature on `handleImageUpload()`

### `calendarService.ts`
- Add `uploadCalendarBackroundImage()`
- Add `getBackgroundImage()`
