### PR TITLE
#120: Implement sharing link for the calendar

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -4,11 +4,13 @@ import cors from "cors";
 const app = express();
 import calendarRouter from "./controllers/calendar";
 import authRouter from "./controllers/auth";
+import publishRouter from "./controllers/publish";
 
 app.use(cors({ origin: "http://localhost:5173" }));
 app.use(helmet());
 app.use(express.json());
 app.use("/api/calendars", calendarRouter);
 app.use("/auth", authRouter);
+app.use("/published", publishRouter);
 
 export default app;

--- a/backend/controllers/publish.ts
+++ b/backend/controllers/publish.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import {
   addToPublishedCalendars,
   getPublishedCalendar,
+  removeFromPublishedCalendars,
 } from "../services/firebaseService";
 
 const publishRouter = express.Router();
@@ -33,5 +34,20 @@ publishRouter.post("/:uid", async (request: Request, response: Response) => {
     throw error;
   }
 });
+
+// Remove calendar from "published_calendars" collection
+publishRouter.delete(
+  "/:uid/:calendarId",
+  async (request: Request, response: Response) => {
+    try {
+      const { uid, calendarId } = request.params;
+      await removeFromPublishedCalendars(uid, calendarId);
+      response.status(204).end();
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+);
 
 export default publishRouter;

--- a/backend/controllers/publish.ts
+++ b/backend/controllers/publish.ts
@@ -1,0 +1,37 @@
+import express, { Request, Response } from "express";
+import {
+  addToPublishedCalendars,
+  getPublishedCalendar,
+} from "../services/firebaseService";
+
+const publishRouter = express.Router();
+
+// Return published user's calendar
+publishRouter.get(
+  "/:uid/:calendarId",
+  async (request: Request, response: Response) => {
+    try {
+      const { uid, calendarId } = request.params;
+      const dbResponse = await getPublishedCalendar(uid, calendarId);
+      return response.status(200).json(dbResponse);
+    } catch (error) {
+      console.log(error);
+      throw error;
+    }
+  }
+);
+
+// Post calendar to "published_calendars" collection
+publishRouter.post("/:uid", async (request: Request, response: Response) => {
+  try {
+    const uid = request.params.uid;
+    const calendar = request.body;
+    const dbResponse = await addToPublishedCalendars(uid, calendar);
+    return response.status(201).json(dbResponse);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+});
+
+export default publishRouter;

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -332,7 +332,6 @@ const getPublishedCalendar = async (uid: string, calendarId: string) => {
       `published_calendars/${uid}/published_calendars`
     );
     const docRef = doc(collectionRef, calendarId);
-    // const calendarObject = (await getDoc(docRef)).data();
     const calendarSnapshot = await getDoc(docRef);
     const calendarObject = calendarSnapshot.data();
     return calendarObject;

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -23,6 +23,8 @@ import {
   where,
   updateDoc,
   deleteDoc,
+  setDoc,
+  getDoc,
 } from "firebase/firestore";
 import { FIREBASE_API_KEY } from "../utils/config";
 import { CalendarData } from "../types/calendarInterface";
@@ -322,6 +324,46 @@ const getCalendarBackgroundDownloadUrl = async (
   }
 };
 
+// Get a published calendar from the "published_calendars" collection
+const getPublishedCalendar = async (uid: string, calendarId: string) => {
+  try {
+    const collectionRef = collection(
+      db,
+      `published_calendars/${uid}/published_calendars`
+    );
+    const docRef = doc(collectionRef, calendarId);
+    // const calendarObject = (await getDoc(docRef)).data();
+    const calendarSnapshot = await getDoc(docRef);
+    const calendarObject = calendarSnapshot.data();
+    return calendarObject;
+  } catch (error) {
+    console.error("Error when fetching published calendar:", error);
+    throw error;
+  }
+};
+
+// Adds a calendar instance in the "published_calendars" collection
+const addToPublishedCalendars = async (uid: string, calendar: CalendarData) => {
+  try {
+    const collectionRef = collection(
+      db,
+      `published_calendars/${uid}/published_calendars`
+    );
+    const calendarId = calendar.calendarId;
+
+    // Add the calendar document with calendarId is the doc id to the "published_calendars" collection
+    const publishedCalendar = await setDoc(
+      doc(collectionRef, calendarId),
+      calendar
+    );
+
+    return publishedCalendar;
+  } catch (error) {
+    console.error("Error when posting to published calendars:", error);
+    throw error;
+  }
+};
+
 export {
   auth,
   db,
@@ -336,4 +378,6 @@ export {
   removeCalendarFromFirebase,
   updateCalendarField,
   updateCalendarObjectInFirebase,
+  getPublishedCalendar,
+  addToPublishedCalendars,
 };

--- a/backend/services/firebaseService.ts
+++ b/backend/services/firebaseService.ts
@@ -364,6 +364,24 @@ const addToPublishedCalendars = async (uid: string, calendar: CalendarData) => {
   }
 };
 
+// Remove calendar from published calendars
+const removeFromPublishedCalendars = async (
+  uid: string,
+  calendarId: string
+) => {
+  try {
+    const collectionRef = collection(
+      db,
+      `published_calendars/${uid}/published_calendars`
+    );
+    const docRef = doc(collectionRef, calendarId);
+    await deleteDoc(docRef);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
 export {
   auth,
   db,
@@ -380,4 +398,5 @@ export {
   updateCalendarObjectInFirebase,
   getPublishedCalendar,
   addToPublishedCalendars,
+  removeFromPublishedCalendars,
 };

--- a/frontend/src/routes/Calendars.tsx
+++ b/frontend/src/routes/Calendars.tsx
@@ -158,7 +158,13 @@ const Calendars = () => {
                     <TableCell>{calendar.calendarDoors.length}</TableCell>
                     <TableCell>{calendar.tags.join(", ")}</TableCell>
                     <TableCell>
-                      {calendar.published ? "Published" : "Unpublished"}
+                      {calendar.published ? (
+                        <Link to={`published/${uid}/${calendar.calendarId}`}>
+                          Published
+                        </Link>
+                      ) : (
+                        "Unpublished"
+                      )}
                     </TableCell>
                     <TableCell>
                       <IconButton

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import DateSelector from "../components/DateSelector";
 import BackgroundColourSelector from "../components/BackgroundColourSelector";
 import UploadImage from "../components/UploadImage";
+import Button from "@mui/material/Button";
 import { useDispatch, useSelector } from "react-redux";
 import {
   ReduxCalendarState,
@@ -19,6 +20,7 @@ import {
   setAuthorNameColour,
   setCalendarTags,
   setCalendarBackgroundUrl,
+  setPublishStatus,
 } from "../store/calendarSlice";
 import CalendarTags from "../components/CalendarTags";
 import { setIsTyping, setSaved } from "../store/syncSlice";
@@ -32,6 +34,7 @@ import {
   CalendarData,
   DoorData,
 } from "../../../backend/types/calendarInterface";
+import { addToPublishedCalendars } from "../services/publishService";
 
 const EditorViewMain: React.FC = () => {
   const [showGeneralSettings, setShowGeneralSettings] = useState<boolean>(true);
@@ -245,6 +248,21 @@ const EditorViewMain: React.FC = () => {
     dispatch(setCalendarBackgroundUrl({ calendarIndex, newBackgroundUrl: "" }));
   };
 
+  const handlePublish = async () => {
+    try {
+      if (!calendar.published) {
+        dispatch(setPublishStatus({ calendarIndex, newPublishStatus: true }));
+        await addToPublishedCalendars(uid, calendar);
+      } else {
+        dispatch(setPublishStatus({ calendarIndex, newPublishStatus: false }));
+      }
+      dispatch(setIsTyping(true));
+      typingResetTimer(timerRef);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   return (
     <Box>
       <Box
@@ -389,6 +407,23 @@ const EditorViewMain: React.FC = () => {
             )}
           </Box>
         </Box>
+        {calendar.published ? (
+          <Button
+            variant="contained"
+            sx={{ my: "1rem" }}
+            onClick={handlePublish}
+          >
+            Unpublish calendar
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            sx={{ my: "1rem" }}
+            onClick={handlePublish}
+          >
+            Publish calendar
+          </Button>
+        )}
         <Typography
           variant="h2"
           sx={{ m: "2rem 0px 1rem", fontWeight: "bold" }}

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -34,7 +34,10 @@ import {
   CalendarData,
   DoorData,
 } from "../../../backend/types/calendarInterface";
-import { addToPublishedCalendars } from "../services/publishService";
+import {
+  addToPublishedCalendars,
+  removeFromPublishedCalendars,
+} from "../services/publishService";
 
 const EditorViewMain: React.FC = () => {
   const [showGeneralSettings, setShowGeneralSettings] = useState<boolean>(true);
@@ -248,6 +251,8 @@ const EditorViewMain: React.FC = () => {
     dispatch(setCalendarBackgroundUrl({ calendarIndex, newBackgroundUrl: "" }));
   };
 
+  // If publish status is false then post published_calendars to published collection.
+  // Else remove from published_calendars collection
   const handlePublish = async () => {
     try {
       if (!calendar.published) {
@@ -255,6 +260,7 @@ const EditorViewMain: React.FC = () => {
         await addToPublishedCalendars(uid, calendar);
       } else {
         dispatch(setPublishStatus({ calendarIndex, newPublishStatus: false }));
+        await removeFromPublishedCalendars(uid, calendarId);
       }
       dispatch(setIsTyping(true));
       typingResetTimer(timerRef);
@@ -407,23 +413,9 @@ const EditorViewMain: React.FC = () => {
             )}
           </Box>
         </Box>
-        {calendar.published ? (
-          <Button
-            variant="contained"
-            sx={{ my: "1rem" }}
-            onClick={handlePublish}
-          >
-            Unpublish calendar
-          </Button>
-        ) : (
-          <Button
-            variant="contained"
-            sx={{ my: "1rem" }}
-            onClick={handlePublish}
-          >
-            Publish calendar
-          </Button>
-        )}
+        <Button variant="contained" sx={{ my: "1rem" }} onClick={handlePublish}>
+          {calendar.published ? "Unpublish calendar" : "Publish calendar"}
+        </Button>
         <Typography
           variant="h2"
           sx={{ m: "2rem 0px 1rem", fontWeight: "bold" }}

--- a/frontend/src/services/publishService.ts
+++ b/frontend/src/services/publishService.ts
@@ -22,4 +22,21 @@ const getPublishedCalendar = async (uid: string, calendarId: string) => {
   }
 };
 
-export { addToPublishedCalendars, getPublishedCalendar };
+const removeFromPublsihedCalendars = async (
+  uid: string,
+  calendarId: string
+) => {
+  try {
+    const response = await axios.delete(`${baseUrl}/${uid}/${calendarId}`);
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export {
+  addToPublishedCalendars,
+  getPublishedCalendar,
+  removeFromPublsihedCalendars,
+};

--- a/frontend/src/services/publishService.ts
+++ b/frontend/src/services/publishService.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+import { CalendarData } from "../../../backend/types/calendarInterface";
+const baseUrl: string = "http://localhost:3001/published";
+
+const addToPublishedCalendars = async (uid: string, calendar: CalendarData) => {
+  try {
+    const response = await axios.post(`${baseUrl}/${uid}`, calendar);
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+const getPublishedCalendar = async (uid: string, calendarId: string) => {
+  try {
+    const response = await axios.get(`${baseUrl}/${uid}/${calendarId}`);
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export { addToPublishedCalendars, getPublishedCalendar };

--- a/frontend/src/services/publishService.ts
+++ b/frontend/src/services/publishService.ts
@@ -22,7 +22,7 @@ const getPublishedCalendar = async (uid: string, calendarId: string) => {
   }
 };
 
-const removeFromPublsihedCalendars = async (
+const removeFromPublishedCalendars = async (
   uid: string,
   calendarId: string
 ) => {
@@ -38,5 +38,5 @@ const removeFromPublsihedCalendars = async (
 export {
   addToPublishedCalendars,
   getPublishedCalendar,
-  removeFromPublsihedCalendars,
+  removeFromPublishedCalendars,
 };

--- a/frontend/src/store/calendarSlice.ts
+++ b/frontend/src/store/calendarSlice.ts
@@ -55,9 +55,13 @@ export const calendarSlice = createSlice({
     setCalendarDoors: (state, action: PayloadAction<{calendarIndex: number, newDoors: DoorData[]}>) => {
       const { calendarIndex, newDoors } = action.payload;
       state.calendars[calendarIndex].calendarDoors = newDoors;
+    },
+    setPublishStatus: (state,action: PayloadAction<{calendarIndex: number, newPublishStatus: boolean}>) => {
+      const { calendarIndex, newPublishStatus } = action.payload;
+      state.calendars[calendarIndex].published = newPublishStatus;
     }  
   },
 });
 
-export const { setCalendars, setCalendarDoors, setCalendarTitle, setCalendarTitleColour, setAuthorName, setAuthorNameColour, setStartDate, setEndDate, setCalendarTags, setCalendarBackgroundUrl, setCalendarBackgroundColour } = calendarSlice.actions;
+export const { setCalendars, setCalendarDoors, setCalendarTitle, setCalendarTitleColour, setAuthorName, setAuthorNameColour, setStartDate, setEndDate, setCalendarTags, setCalendarBackgroundUrl, setCalendarBackgroundColour, setPublishStatus } = calendarSlice.actions;
 export default calendarSlice.reducer;


### PR DESCRIPTION
# #120: Implement sharing link for the calendar

Users can now publish their calendars from `EditorViewMain.tsx` if they press "Publish" button. Users can also unpublish their calendars if the calendars are already published by pressing "Unpublish" button on the page.

The public link for the calendar will be generated in /published/`uid`/`calendarId` and is accessible for anyone with the link. Link will appear in the `Calendars.tsx` table.

## Backend

### `app.ts`
- Import `publishRouter`

### `publish.ts`
- Router to handle "published_calendars" collection HTTP requests (DELETE, POST and GET)

### `firebaseService.ts`
- Added `getPublishedCalendar()`, `addToPublishedCalendars()` and `removeFromPublishedCalendars()`

## Frontend

### `Calendats.tsx`
- Conditionally render a link to publsihed calendar if calendar's publish status is true

### `EditorViewMain.tsx`
- Add `addHandlePublish()` function to handle publishing calendars
- Add button to fire `addHandlePublish()`

### `PublishService.ts`
- Add functions for POST, GET and DELETE operations

### `calendarSlice.ts`
- Add `setPublishStatus` reducer

