### PR TITLE
#121: Create confirmation modal

### DIFF
--- a/frontend/src/components/ModalDialog.tsx
+++ b/frontend/src/components/ModalDialog.tsx
@@ -1,0 +1,43 @@
+import Dialog from "@mui/material/Dialog";
+import Button from "@mui/material/Button";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+
+interface ModalDialogProps {
+  titleText: string;
+  dialogText: string;
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ModalDialog = ({
+  titleText,
+  dialogText,
+  open,
+  onConfirm,
+  onCancel,
+}: ModalDialogProps) => {
+  return (
+    <Dialog open={open}>
+      <DialogTitle>{titleText}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ color: "black" }}>
+          {dialogText}
+        </DialogContentText>
+        <DialogActions>
+          <Button variant="contained" color="secondary" onClick={onConfirm}>
+            Yes
+          </Button>
+          <Button variant="contained" color="secondary" onClick={onCancel}>
+            No
+          </Button>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ModalDialog;

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -264,8 +264,8 @@ const EditorViewMain: React.FC = () => {
     setOpenModal(false);
     try {
       if (!calendar.published) {
-        dispatch(setPublishStatus({ calendarIndex, newPublishStatus: true }));
         await addToPublishedCalendars(uid, calendar);
+        dispatch(setPublishStatus({ calendarIndex, newPublishStatus: true }));
         dispatch(
           setAlert({
             isVisible: true,
@@ -274,8 +274,8 @@ const EditorViewMain: React.FC = () => {
           })
         );
       } else {
-        dispatch(setPublishStatus({ calendarIndex, newPublishStatus: false }));
         await removeFromPublishedCalendars(uid, calendarId);
+        dispatch(setPublishStatus({ calendarIndex, newPublishStatus: false }));
         dispatch(
           setAlert({
             isVisible: true,
@@ -286,11 +286,21 @@ const EditorViewMain: React.FC = () => {
       }
       dispatch(setIsTyping(true));
       typingResetTimer(timerRef);
-    } catch (error) {
+    } catch (error: any) {
       console.error(error);
-      // dispatch(
-      //   setAlert({ isVisible: true, message: error, severity: "error" })
-      // );
+      if (error.message) {
+        dispatch(
+          setAlert({
+            isVisible: true,
+            message: error.message,
+            severity: "error",
+          })
+        );
+      } else {
+        dispatch(
+          setAlert({ isVisible: true, message: error, severity: "error" })
+        );
+      }
     }
   };
 

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -39,6 +39,8 @@ import {
   addToPublishedCalendars,
   removeFromPublishedCalendars,
 } from "../services/publishService";
+import AlertHandler from "../components/AlertHandler";
+import { setAlert } from "../store/alertSlice";
 
 const EditorViewMain: React.FC = () => {
   const [showGeneralSettings, setShowGeneralSettings] = useState<boolean>(true);
@@ -264,14 +266,31 @@ const EditorViewMain: React.FC = () => {
       if (!calendar.published) {
         dispatch(setPublishStatus({ calendarIndex, newPublishStatus: true }));
         await addToPublishedCalendars(uid, calendar);
+        dispatch(
+          setAlert({
+            isVisible: true,
+            message: "Calendar published succesfully",
+            severity: "success",
+          })
+        );
       } else {
         dispatch(setPublishStatus({ calendarIndex, newPublishStatus: false }));
         await removeFromPublishedCalendars(uid, calendarId);
+        dispatch(
+          setAlert({
+            isVisible: true,
+            message: "Calendar unpublished succesfully",
+            severity: "success",
+          })
+        );
       }
       dispatch(setIsTyping(true));
       typingResetTimer(timerRef);
     } catch (error) {
       console.error(error);
+      // dispatch(
+      //   setAlert({ isVisible: true, message: error, severity: "error" })
+      // );
     }
   };
 
@@ -299,6 +318,7 @@ const EditorViewMain: React.FC = () => {
         onConfirm={handlePublish}
         onCancel={handleCloseModal}
       />
+      <AlertHandler />
       <Box
         sx={{
           width: "100%",

--- a/frontend/src/routes/EditorViewMain.tsx
+++ b/frontend/src/routes/EditorViewMain.tsx
@@ -6,6 +6,7 @@ import DateSelector from "../components/DateSelector";
 import BackgroundColourSelector from "../components/BackgroundColourSelector";
 import UploadImage from "../components/UploadImage";
 import Button from "@mui/material/Button";
+import ModalDialog from "../components/ModalDialog";
 import { useDispatch, useSelector } from "react-redux";
 import {
   ReduxCalendarState,
@@ -49,6 +50,9 @@ const EditorViewMain: React.FC = () => {
   const [showImageUpload, setShowImageUpload] = useState<boolean>(false);
   const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
   const [singleTag, setSingleTag] = useState<string>("");
+  const [openModal, setOpenModal] = useState<boolean>(false);
+  const [dialogText, setDialogText] = useState<string>("");
+  const [dialogTitle, setDialogTitle] = useState<string>("");
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -251,9 +255,11 @@ const EditorViewMain: React.FC = () => {
     dispatch(setCalendarBackgroundUrl({ calendarIndex, newBackgroundUrl: "" }));
   };
 
+  // If user clicked yes on ModalDialog then close modal and run function
   // If publish status is false then post published_calendars to published collection.
   // Else remove from published_calendars collection
   const handlePublish = async () => {
+    setOpenModal(false);
     try {
       if (!calendar.published) {
         dispatch(setPublishStatus({ calendarIndex, newPublishStatus: true }));
@@ -269,8 +275,30 @@ const EditorViewMain: React.FC = () => {
     }
   };
 
+  // Set the content for modal
+  const confirmPublishCalendar = () => {
+    setOpenModal(true);
+    setDialogTitle("Publish calendar");
+    setDialogText(
+      `Are you sure you want to ${
+        calendar.published ? "unpublish" : "publish"
+      } this calendar?`
+    );
+  };
+
+  const handleCloseModal = () => {
+    setOpenModal(false);
+  };
+
   return (
     <Box>
+      <ModalDialog
+        open={openModal}
+        titleText={dialogTitle}
+        dialogText={dialogText}
+        onConfirm={handlePublish}
+        onCancel={handleCloseModal}
+      />
       <Box
         sx={{
           width: "100%",
@@ -413,7 +441,11 @@ const EditorViewMain: React.FC = () => {
             )}
           </Box>
         </Box>
-        <Button variant="contained" sx={{ my: "1rem" }} onClick={handlePublish}>
+        <Button
+          variant="contained"
+          sx={{ my: "1rem" }}
+          onClick={confirmPublishCalendar}
+        >
           {calendar.published ? "Unpublish calendar" : "Publish calendar"}
         </Button>
         <Typography

--- a/frontend/src/services/publishService.ts
+++ b/frontend/src/services/publishService.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { isAxiosError } from "axios";
 import { CalendarData } from "../../../backend/types/calendarInterface";
 const baseUrl: string = "http://localhost:3001/published";
 
@@ -7,6 +7,9 @@ const addToPublishedCalendars = async (uid: string, calendar: CalendarData) => {
     const response = await axios.post(`${baseUrl}/${uid}`, calendar);
     return response;
   } catch (error) {
+    if (isAxiosError(error) && error.code === "ERR_NETWORK") {
+      throw new Error("Network Error");
+    }
     console.error(error);
     throw error;
   }
@@ -17,6 +20,9 @@ const getPublishedCalendar = async (uid: string, calendarId: string) => {
     const response = await axios.get(`${baseUrl}/${uid}/${calendarId}`);
     return response;
   } catch (error) {
+    if (isAxiosError(error) && error.code === "ERR_NETWORK") {
+      throw new Error("Network Error");
+    }
     console.error(error);
     throw error;
   }
@@ -30,7 +36,9 @@ const removeFromPublishedCalendars = async (
     const response = await axios.delete(`${baseUrl}/${uid}/${calendarId}`);
     return response;
   } catch (error) {
-    console.error(error);
+    if (isAxiosError(error) && error.code === "ERR_NETWORK") {
+      throw new Error("Network Error");
+    }
     throw error;
   }
 };


### PR DESCRIPTION
# #121: Create confirmation modal
<img width="735" alt="Screenshot 2024-05-15 at 18 27 34" src="https://github.com/meJubair/SWTP2/assets/118634468/7512ce53-3a0f-46b1-8039-4cc894ca53b1">

Users get a little confirmation action before publishing, unpublishing or deleting a calendar.
- Created `ModalDialog.tsx` to handle the user's confirmation
- Implemented logic for handling user confirmation in `EditorViewMain.tsx` and `Calendars.tsx`